### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# This file tells which files and directories should be ignored and
+# NOT downloaded when using composer to pull down a project with
+# the --prefer-dist option selected. Used to remove development
+# specific files so user has a clean download.
+
+/application/ export-ignore
+/public/ export-ignore
+/writable/ export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/env export-ignore
+/phpunit.xml.dist export-ignore
+/spark export-ignore


### PR DESCRIPTION
For example, in `appstarter`, it will be in `vendor` directory, so the following directories and files need to be ignored from download:

```
/application/ 
/public/ 
/writable/ 
/.gitignore 
/.travis.yml 
/env 
/phpunit.xml.dist 
/spark 
```