### PR TITLE
Add clearAll method (alias of clear)

### DIFF
--- a/system/Email/Email.php
+++ b/system/Email/Email.php
@@ -438,6 +438,17 @@ class Email
 	}
 	//--------------------------------------------------------------------
 	/**
+	 * Alias of clear(true)
+	 * Initialize the Email Data.
+	 *
+	 * @return Email
+	 */
+	public function clearAll()
+	{
+		return $this->clear(true);
+	}
+	//--------------------------------------------------------------------
+	/**
 	 * Set FROM
 	 *
 	 * @param string      $from


### PR DESCRIPTION
I think the default behavior of clear() should be to remove attachments, instead of leaving them in the message.  I think it can lead to issues where unknowing developers send attachments to people they don't intend to.

I've also seen at least one post on Stack Overflow wondering why attachments are not being removed.  Changing the default behavior at this point would be a breaking change which could lead to additional problems as people try to upgrade.  I think adding this method is the least painful way to improve the behavior while not introducing a breaking change.