### PR TITLE
PHP Fatal error:  Uncaught Error: Class 'Config\App' not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "autoload": {
         "psr-4": {
             "CodeIgniter\\": "system/",
-            "Config\\": "app/"
+            "Config\\": "app/",
+            "App\\": "app/"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     },
     "autoload": {
         "psr-4": {
-            "CodeIgniter\\": "system/"
+            "CodeIgniter\\": "system/",
+            "Config\\": "app/"
         }
     },
     "scripts": {


### PR DESCRIPTION
Both downloads i.e composer and manual installation were throwing the error above. Adding "Config\\": "app/" to composer.json file fixed the issue