### PR TITLE
Removing running of "bash admin/setup.sh" from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
     "scripts": {
         "post-update-cmd": [
             "@composer dump-autoload",
-            "CodeIgniter\\ComposerScripts::postUpdate",
-            "bash admin/setup.sh"
+            "CodeIgniter\\ComposerScripts::postUpdate"
         ]
     },
     "support": {


### PR DESCRIPTION
Whole directory admin/ doesn't exist in codeigniter4/framework repo in comparison to codeigniter4/CodeIgniter4 repo.