### PR TITLE
fix: check for binds following variable naming convention

### DIFF
--- a/system/Database/Query.php
+++ b/system/Database/Query.php
@@ -368,7 +368,7 @@ class Query implements QueryInterface
 	{
 		$sql = $this->finalQueryString;
 
-		$hasNamedBinds = strpos($sql, ':') !== false && strpos($sql, ':=') === false;
+		$hasNamedBinds = preg_match('/:[a-zA-Z_]/') && strpos($sql, ':=') === false;
 
 		if (empty($this->binds) || empty($this->bindMarker) ||
 				(strpos($sql, $this->bindMarker) === false &&


### PR DESCRIPTION
The proposed change is to allow corner cases where $sql being passed
might already contain a DATETIME constraint that would be detected as a
named bind even though you could be wanting to do a simple bind.
Ex WHERE some_column = ? AND other_column = ?
(date_column IS NULL OR false_positive_1 LIKE '%05:48%' OR false_positive_2  LIKE '%05:48%') 

Signed-off-by: Guy-Robert Kernisant <grkernisant@gmail.com>